### PR TITLE
Add a version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,15 @@ default: install server
 
 build: server client
 
+VERSION      := $(shell pulumictl get version)
+LINK_VERSION := -ldflags "-X github.com/pulumi/pulumi-lsp/sdk/version.Version=${VERSION}"
+
 server:
 	mkdir -p ./bin
-	${GO} build -o ./bin -p ${CONCURRENCY} ./cmd/...
+	${GO} build ${LINK_VERSION} -o ./bin -p ${CONCURRENCY} ./cmd/...
 
 install: server
-	${GO} install ./cmd/...
+	${GO} install ${LINK_VERSION} ./cmd/...
 
 client: emacs-client vscode-client
 

--- a/cmd/pulumi-lsp/main.go
+++ b/cmd/pulumi-lsp/main.go
@@ -4,31 +4,85 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"runtime"
+	"runtime/debug"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi-lsp/sdk/lsp"
+	"github.com/pulumi/pulumi-lsp/sdk/version"
 	"github.com/pulumi/pulumi-lsp/sdk/yaml"
 )
 
 func main() {
-	host, err := defaultPluginHost()
-	if err != nil {
-		panic(err)
+	defer panicHandler()
+	if err := newLSPCommand().Execute(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
+		// We ignore the error, since there is nothing to do with it
+		os.Exit(1)
 	}
-	defer func() {
-		if err := host.Close(); err != nil {
-			panic(err)
-		}
-	}()
-	server := lsp.NewServer(yaml.Methods(host), &stdio{false})
-	err = server.Run(context.Background())
-	if err != nil {
-		panic(err)
+}
+
+func newLSPCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pulumi-lsp",
+		Short: "A LSP for Pulumi YAML",
+		Args:  cobra.NoArgs,
+		Run: func(*cobra.Command, []string) {
+			host, err := defaultPluginHost()
+			if err != nil {
+				panic(err)
+			}
+			defer func() {
+				if err := host.Close(); err != nil {
+					panic(err)
+				}
+			}()
+			server := lsp.NewServer(yaml.Methods(host), &stdio{false})
+			err = server.Run(context.Background())
+			if err != nil {
+				panic(err)
+			}
+		},
+	}
+
+	cmd.AddCommand(newVersionCmd())
+	return cmd
+}
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print Pulumi's version number",
+		Args:  cobra.NoArgs,
+		Run: func(*cobra.Command, []string) {
+			fmt.Printf("%v\n", version.Version)
+		},
+	}
+}
+
+func panicHandler() {
+	if panicPayload := recover(); panicPayload != nil {
+		stack := string(debug.Stack())
+		fmt.Fprintln(os.Stderr, "================================================================================")
+		fmt.Fprintln(os.Stderr, "Pulumi LSP encountered a fatal error. This is a bug!")
+		fmt.Fprintln(os.Stderr, "We would appreciate a report: https://github.com/pulumi/pulumi-lsp/issues/")
+		fmt.Fprintln(os.Stderr, "Please provide all of the below text in your report.")
+		fmt.Fprintln(os.Stderr, "================================================================================")
+		fmt.Fprintf(os.Stderr, "pulumi-lsp Version:   %s\n", version.Version)
+		fmt.Fprintf(os.Stderr, "Go Version:           %s\n", runtime.Version())
+		fmt.Fprintf(os.Stderr, "Go Compiler:          %s\n", runtime.Compiler)
+		fmt.Fprintf(os.Stderr, "Architecture:         %s\n", runtime.GOARCH)
+		fmt.Fprintf(os.Stderr, "Operating System:     %s\n", runtime.GOOS)
+		fmt.Fprintf(os.Stderr, "Panic:                %s\n\n", panicPayload)
+		fmt.Fprintln(os.Stderr, stack)
+		os.Exit(1)
 	}
 }
 

--- a/sdk/version/version.go
+++ b/sdk/version/version.go
@@ -1,0 +1,6 @@
+// Copyright 2022, Pulumi Corporation.  All rights reserved.
+
+package version
+
+// Version is initialized by the Go linker to contain the semver of this build.
+var Version string

--- a/sdk/yaml/yaml.go
+++ b/sdk/yaml/yaml.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pulumi/pulumi-lsp/sdk/lsp"
 	"github.com/pulumi/pulumi-lsp/sdk/util"
+	"github.com/pulumi/pulumi-lsp/sdk/version"
 )
 
 // The holder server level state.
@@ -38,7 +39,7 @@ func Methods(host plugin.Host) *lsp.Methods {
 		DidChangeFunc:  server.didChange,
 		HoverFunc:      server.hover,
 		CompletionFunc: server.completion,
-	}.DefaultInitializer("pulumi-lsp", "0.1.0")
+	}.DefaultInitializer("pulumi-lsp", version.Version)
 }
 
 func (s *server) setDocument(text lsp.Document) *document {


### PR DESCRIPTION
This also includes link-time support for addding the version and adds a dependency on `pulumictl` to calculate the version. In the spirit of conformity and idiomatic go, `pulumi-lsp version`  is used instead of `pulumi-lsp --version`. 