### PR TITLE
Support autocomplete for `Fn::` shorthand

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,4 +9,7 @@
 - [completion] Add support for the `defaultProvider` resource field.
   [#47](https://github.com/pulumi/pulumi-lsp/pull/47)
 
+- [completion] Add support for completing `Fn::*`.
+  [#48](https://github.com/pulumi/pulumi-lsp/pull/48)
+
 ### Bug Fixes

--- a/sdk/step/step.go
+++ b/sdk/step/step.go
@@ -23,6 +23,9 @@ type Step[T any] struct {
 // is true if a computed value is returned. False indicates that the attempt
 // failed.
 func (s *Step[T]) TryGetResult() (T, bool) {
+	if s == nil {
+		return Zero[T](), false
+	}
 	select {
 	case <-s.done:
 		return s.data, true

--- a/sdk/util/util.go
+++ b/sdk/util/util.go
@@ -26,6 +26,16 @@ func MapOver[T any, U any, F func(T) U](arr []T, f F) []U {
 	return l
 }
 
+func FilterMap[T any, U any, F func(T) *U](arr []T, f F) []U {
+	l := make([]U, 0, len(arr))
+	for _, t := range arr {
+		if v := f(t); v != nil {
+			l = append(l, *v)
+		}
+	}
+	return l
+}
+
 type Tuple[A any, B any] struct {
 	A A
 	B B

--- a/sdk/util/util.go
+++ b/sdk/util/util.go
@@ -76,3 +76,14 @@ func ReverseList[T any](l []T) []T {
 	}
 	return rev
 }
+
+func StripNils[T any](l []*T) []*T {
+	out := make([]*T, 0, len(l))
+	for _, v := range l {
+		if v == nil {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}

--- a/sdk/yaml/bind/bind.go
+++ b/sdk/yaml/bind/bind.go
@@ -526,6 +526,8 @@ func (b *Decl) bind(e ast.Expr) error {
 
 	case *ast.ReadFileExpr:
 		return b.bind(e.Path)
+	case *ast.SecretExpr:
+		return b.bind(e.Value)
 
 	// Stack reference
 	case *ast.StackReferenceExpr:

--- a/sdk/yaml/bind/bind.go
+++ b/sdk/yaml/bind/bind.go
@@ -524,6 +524,9 @@ func (b *Decl) bind(e ast.Expr) error {
 	case *ast.RemoteAssetExpr:
 	case *ast.StringAssetExpr:
 
+	case *ast.ReadFileExpr:
+		return b.bind(e.Path)
+
 	// Stack reference
 	case *ast.StackReferenceExpr:
 

--- a/sdk/yaml/completion.go
+++ b/sdk/yaml/completion.go
@@ -573,86 +573,35 @@ func providedCompletions(
 }
 
 func completeResourceOptionsKeys(doc *document, keyPos protocol.Position, post postFix) (*protocol.CompletionList, error) {
-	sibs, err := childKeys(doc.text, keyPos)
-	if err != nil {
-		return nil, err
-	}
-	setDetails := func(detail, doc string, post func(int) string) func(*protocol.CompletionItem) {
-		return func(c *protocol.CompletionItem) {
-			c.Detail = detail
-			// We are indenting to the forth level
-			// resources:
-			//   name:
-			//     options:
-			//       what we are suggestion
-			c.InsertText = c.Label + post(4)
-			c.Documentation = doc
-			c.InsertTextMode = protocol.InsertTextModeAsIs
-		}
-	}
-
-	return &protocol.CompletionList{
-		Items: uniqueCompletions(util.MapOver(util.MapKeys(sibs), func(s string) string {
-			s = strings.ToLower(s)
-			s = strings.TrimSpace(s)
-			parts := strings.Split(s, ":")
-			if len(parts) > 0 {
-				s = parts[0]
-			}
-			return s
-		}), []util.Tuple[string, func(*protocol.CompletionItem)]{
-			{A: "additionalSecretOutputs",
-				B: setDetails("List<String>",
-					"AdditionalSecretOutputs specifies properties that must be encrypted as secrets",
-					post.intoList)},
-			{A: "aliases",
-				B: setDetails("List<String>",
-					"Aliases specifies names that this resource used to be have so that renaming or refactoring doesn’t replace it",
-					post.intoList)},
-			{A: "customTimeouts",
-				B: setDetails("CustomTimeout",
-					"CustomTimeouts overrides the default retry/timeout behavior for resource provisioning",
-					post.intoObject)},
-			{A: "deleteBeforeReplace",
-				B: setDetails("Boolean",
-					"DeleteBeforeReplace overrides the default create-before-delete behavior when replacing",
-					post.sameLine)},
-			{A: "dependsOn",
-				B: setDetails("List<Expression>",
-					"DependsOn makes this resource explicitly depend on another resource, by name, so that it won't be created before the "+
-						"dependent finishes being created (and the reverse for destruction). Normally, Pulumi automatically tracks implicit"+
-						" dependencies through inputs/outputs, but this can be used when dependencies aren't captured purely from input/output edges.",
-					post.intoList)},
-			{A: "ignoreChanges",
-				B: setDetails("List<String>",
-					"IgnoreChanges declares that changes to certain properties should be ignored during diffing",
-					post.intoList)},
-			{A: "import",
-				B: setDetails("String",
-					"Import adopts an existing resource from your cloud account under the control of Pulumi",
-					post.sameLine)},
-			{A: "parent",
-				B: setDetails("Resource",
-					"Parent specifies a parent for the resource",
-					post.sameLine)},
-			{A: "protect",
-				B: setDetails("Boolean",
-					"Protect prevents accidental deletion of a resource",
-					post.sameLine)},
-			{A: "provider",
-				B: setDetails("Provider Resource",
-					"Provider specifies an explicitly configured provider, instead of using the default global provider",
-					post.sameLine)},
-			{A: "providers",
-				B: setDetails("Map<Provider Resource>",
-					"Map of providers for a resource and its children.",
-					post.intoObject)},
-			{A: "version",
-				B: setDetails("String",
-					"Version specifies a provider plugin version that should be used when operating on a resource",
-					post.sameLine)},
-		}),
-	}, nil
+	return providedCompletions(doc, keyPos, 4, []option{
+		{"additionalSecretOutputs", "List<String>",
+			"AdditionalSecretOutputs specifies properties that must be encrypted as secrets", post.intoList},
+		{"aliases", "List<String>",
+			"Aliases specifies names that this resource used to be have so that renaming or refactoring doesn’t replace it", post.intoList},
+		{"customTimeouts", "CustomTimeout",
+			"CustomTimeouts overrides the default retry/timeout behavior for resource provisioning", post.intoObject},
+		{"deleteBeforeReplace", "Boolean",
+			"DeleteBeforeReplace overrides the default create-before-delete behavior when replacing", post.sameLine},
+		{"dependsOn", "List<Expression>",
+			"DependsOn makes this resource explicitly depend on another resource, by name, so that it won't be created before the " +
+				"dependent finishes being created (and the reverse for destruction). Normally, Pulumi automatically tracks implicit" +
+				" dependencies through inputs/outputs, but this can be used when dependencies aren't captured purely from input/output edges.",
+			post.intoList},
+		{"ignoreChanges", "List<String>",
+			"IgnoreChanges declares that changes to certain properties should be ignored during diffing", post.intoList},
+		{"import", "String",
+			"Import adopts an existing resource from your cloud account under the control of Pulumi", post.sameLine},
+		{"parent", "Resource",
+			"Parent specifies a parent for the resource", post.sameLine},
+		{"protect", "Boolean",
+			"Protect prevents accidental deletion of a resource", post.sameLine},
+		{"provider", "Provider Resource",
+			"Provider specifies an explicitly configured provider, instead of using the default global provider", post.sameLine},
+		{"providers", "Map<Provider Resource>",
+			"Map of providers for a resource and its children.", post.intoObject},
+		{"version", "String",
+			"Version specifies a provider plugin version that should be used when operating on a resource", post.sameLine},
+	})
 }
 
 func completeResourceKeys(doc *document, keyPos protocol.Position, postFix postFix) (*protocol.CompletionList, error) {

--- a/sdk/yaml/util.go
+++ b/sdk/yaml/util.go
@@ -138,10 +138,13 @@ func (l SchemaCache) ResolveResource(c lsp.Client, token string) (*schema.Resour
 	}
 	pkg = tokens[0]
 	var isProvider bool
-	if strings.HasPrefix(token, "pulumi:providers:") {
+	if pkg == "pulumi" {
 		isProvider = true
-		pkg = tokens[2]
+		if tokens[1] == "providers" && len(tokens) > 2 {
+			pkg = tokens[2]
+		}
 	}
+
 	schema, err := l.Loader(c).LoadPackageReference(pkg, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Could not resolve resource: %w", err)

--- a/sdk/yaml/util.go
+++ b/sdk/yaml/util.go
@@ -137,12 +137,17 @@ func (l SchemaCache) ResolveResource(c lsp.Client, token string) (*schema.Resour
 		return nil, fmt.Errorf("Invalid token '%s': too few spans", token)
 	}
 	pkg = tokens[0]
+	var isProvider bool
 	if strings.HasPrefix(token, "pulumi:providers:") {
+		isProvider = true
 		pkg = tokens[2]
 	}
 	schema, err := l.Loader(c).LoadPackageReference(pkg, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Could not resolve resource: %w", err)
+	}
+	if isProvider {
+		return schema.Provider()
 	}
 	resolvedToken, err := yaml.NewResourcePackage(schema).ResolveResource(token)
 	if err != nil {


### PR DESCRIPTION
Fixes #46 

This PR adds support for completing on `Fn::`. It includes both builtin functions such as `Fn::Split` and invokes such as `Fn::aws:s3:getBucketObject`.