### PR TITLE
Support option.version for resources and invokes

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,4 +12,10 @@
 - [completion] Add support for completing `Fn::*`.
   [#48](https://github.com/pulumi/pulumi-lsp/pull/48)
 
+- [spec] Account for `Options.Version` when completing fields.
+  [#51](https://github.com/pulumi/pulumi-lsp/pull/51)
+
 ### Bug Fixes
+
+- [completion] Only complete when the cursor is on the text bieng completed.
+  [#51](https://github.com/pulumi/pulumi-lsp/pull/51)

--- a/sdk/yaml/analysis.go
+++ b/sdk/yaml/analysis.go
@@ -102,7 +102,7 @@ func NewDocumentAnalysisPipeline(c lsp.Client, text lsp.Document, loader schema.
 	}
 	go func(c lsp.Client, text lsp.Document, loader schema.ReferenceLoader) {
 		// We need to ensure everything finished when we exit
-		c.LogInfof("Kicking off analysis for %s", text.URI().Filename())
+		c.LogDebugf("Kicking off analysis for %s", text.URI().Filename())
 
 		d.parse(text)
 		step.After(d.parsed, func(util.Tuple[*ast.TemplateDecl, hcl.Diagnostics]) {
@@ -167,7 +167,7 @@ func (d *documentAnalysisPipeline) sendDiags(c lsp.Client, uri protocol.Document
 		}
 
 		lspDiags = append(lspDiags, diagnostic)
-		c.LogInfof("Preparing diagnostic %v", diagnostic)
+		c.LogDebugf("Preparing diagnostic %v", diagnostic)
 	}
 
 	// Diagnostics last until the next publish, so we need to publish even if we

--- a/sdk/yaml/bind/query.go
+++ b/sdk/yaml/bind/query.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Return a list of all resources whose token matches `tk`.
-func (d *Decl) GetResources(tk string) ([]Resource, error) {
+func (d *Decl) GetResources(tk, version string) ([]Resource, error) {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
 	// First we load the token, so we can get the alias list
@@ -19,7 +19,7 @@ func (d *Decl) GetResources(tk string) ([]Resource, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Cannot get resources: %w", err)
 	}
-	pkg, ok := d.loadedPackages[pkgName]
+	pkg, ok := d.loadedPackages[pkgKey{pkgName, version}]
 	// We didn't have access to that package
 	if !ok {
 		return nil, fmt.Errorf(

--- a/sdk/yaml/completion.go
+++ b/sdk/yaml/completion.go
@@ -801,7 +801,7 @@ func getTokenAtLine(text lsp.Document, line int) string {
 func (s *server) completeProperties(
 	c lsp.Client, inputs []*schema.Property, existing []string, postFix postFix, indentLevel int,
 ) (*protocol.CompletionList, error) {
-	props := make([]*schema.Property, len(inputs))
+	props := make([]*schema.Property, 0, len(inputs))
 	es := util.NewSet(util.MapOver(existing, strings.ToLower)...)
 	for _, p := range inputs {
 		if es.Has(strings.ToLower(p.Name)) {

--- a/sdk/yaml/find.go
+++ b/sdk/yaml/find.go
@@ -49,7 +49,11 @@ func (doc *document) objectAtPoint(pos protocol.Position) (Object, error) {
 			if bound.A == nil {
 				return nil, nilError
 			}
-			res, err := bound.A.GetResources(tk)
+			version := ""
+			if v := r.Value.Options.Version; v != nil {
+				version = v.Value
+			}
+			res, err := bound.A.GetResources(tk, version)
 			if err != nil {
 				return nil, err
 			}

--- a/sdk/yaml/util.go
+++ b/sdk/yaml/util.go
@@ -118,7 +118,6 @@ func (l SchemaLoader) LoadPackageReference(pkg string, version *semver.Version) 
 		}
 	}
 	return load, err
-
 }
 
 func (l SchemaLoader) LoadPackage(pkg string, version *semver.Version) (*schema.Package, error) {

--- a/sdk/yaml/yaml.go
+++ b/sdk/yaml/yaml.go
@@ -94,7 +94,6 @@ func (s *server) didClose(client lsp.Client, params *protocol.DidCloseTextDocume
 }
 
 func (s *server) didChange(client lsp.Client, params *protocol.DidChangeTextDocumentParams) error {
-	fileName := params.TextDocument.URI.Filename()
 	uri := params.TextDocument.URI
 	doc, ok := s.getDocument(params.TextDocument.URI)
 	if !ok {
@@ -105,10 +104,8 @@ func (s *server) didChange(client lsp.Client, params *protocol.DidChangeTextDocu
 		// the document.
 		return fmt.Errorf("Document might be unknown: %w", err)
 	}
-	var defRange protocol.Range
-	err := client.LogInfof("%s changed(wholeChange=%t)", fileName, params.ContentChanges[0].Range == defRange)
 	doc.process(client)
-	return err
+	return nil
 }
 
 func (s *server) hover(client lsp.Client, params *protocol.HoverParams) (*protocol.Hover, error) {


### PR DESCRIPTION
This PR brings 2 improvements:
- Commits https://github.com/pulumi/pulumi-lsp/commit/daa52b79eac7a0e46349d2e1a38b3018f652cb22 and https://github.com/pulumi/pulumi-lsp/commit/edab9e01bcd1d6fd12b5ad9355ec9c4b6c3e8eb2 force the LSP server to take the version field into account when retrieving packages.
- Commits 3b2a30de41929d48e3deafa32c999c89d9a9d346, 21dc9314a8d6341d52ac3e4e3ff92144f2c1a30d, 1a9925ec4de5bcb7a0f18e078e2e3336fb7bc9bb and 9ca3cf1e44d7666c9ae74d105392b76526b02a90 improve completion so it only triggers when typing in the correct field (instead of the whole line). 

Fixes #50 