### PR TITLE
Adds a warning when redhat yaml is enabled

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,4 +12,7 @@
 - [completion] Add support for completing `Fn::*`.
   [#48](https://github.com/pulumi/pulumi-lsp/pull/48)
 
+- [editors/vscode] Warn when Red Hat YAML is also installed.
+  [#52](https://github.com/pulumi/pulumi-lsp/pull/52)
+
 ### Bug Fixes

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -47,9 +47,17 @@
                     "type": ["string", "null"],
                     "default": null,
                     "markdownDescription": "Specifies the path to the `pulumi-lsp` binary to use. Leave as `null` to use the binary bundled with the downloaded extension."
+                },
+                "pulumi-lsp.detectExtensionConflicts": {
+                    "type": ["boolean"],
+                    "default": true,
+                    "description": "Warn about conflicting extensions and suggest disabling them."
                 }
             }
         }
     },
-    "icon": "pulumi-logo.png"
+    "icon": "pulumi-logo.png",
+    "bugs": {
+        "url" : "https://github.com/pulumi/pulumi-lsp/issues"
+    }
 }


### PR DESCRIPTION
As @AaronFriel discovered, Pulumi YAML and Red Hat YAML interfere with each other. Specifically Red Hat YAML prevents Pulumi YAML's completion from inserting correctly. 

This PR adds a warning when both are enabled. The only solution I found was to disable Red Hat YAML. The warning has a dialog option to disable Red Hat YAML.

 Looking at other packages, the closest analogy I found was for C++ (clangd & Microsoft C++). It provides a similar solution. I remember that rust presented a similar warning when rust-lsp and rust-analyzer conflicted.

Fixes #49