### PR TITLE
Make version number smaller

### DIFF
--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -97,7 +97,7 @@ jobs:
           if [[ "${{inputs.vsce-full-release}}" == "false" ]]; then
             VERSION=$(./scripts/next-release.sh)
             echo -n "Setting unique version for pre-release: '${VERSION}' ->"
-            VERSION="${VERSION%0}$(date '+%Y%m%d%s')"
+            VERSION="${VERSION%0}$(date '+%Y%m%d%S')"
             echo " '${VERSION}'"
           else
             VERSION=$(git describe --match 'v*.*.*')

--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -93,17 +93,14 @@ jobs:
           mkdir bin
           cp LICENSE editors/vscode/LICENSE
           cp README.md editors/vscode/README.md
-          VERSION=$(./scripts/next-release.sh)
-          if [[ "${VERSION}" == "" ]]; then
-            echo "Empty version"
-            exit 1
-          fi
           VERSION=${VERSION#v}
           if [[ "${{inputs.vsce-full-release}}" == "false" ]]; then
+            VERSION=$(./scripts/next-release.sh)
             echo -n "Setting unique version for pre-release: '${VERSION}' ->"
-            VERSION="${VERSION}$(date '+%Y%m%d%s')"
+            VERSION="${VERSION%0}$(date '+%Y%m%d%s')"
             echo " '${VERSION}'"
           else
+            VERSION=$(git describe --match 'v*.*.*')
             echo "Setting release version: '${VERSION}'"
           fi
           jq ".version=\"${VERSION}\"" editors/vscode/package.json > tmp.json

--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -93,8 +93,7 @@ jobs:
           mkdir bin
           cp LICENSE editors/vscode/LICENSE
           cp README.md editors/vscode/README.md
-          git fetch --tags
-          VERSION=$(git describe --tags --match 'v*.*.*' main | sed 's/\-.*//')
+          VERSION=$(./scripts/next-release.sh)
           if [[ "${VERSION}" == "" ]]; then
             echo "Empty version"
             exit 1

--- a/scripts/next-release.sh
+++ b/scripts/next-release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Get the next minor release based on existing tags.
+
+set -euo pipefail
+
+git fetch --tags
+VERSION=$(git tag --list 'v*.*.*' | tail -1)
+MAJOR=$(echo $VERSION | sed 's/\..*//')
+MAJOR=${MAJOR#v}
+MINOR=$(echo ${VERSION#v$MAJOR.} | sed 's/\..*//')
+
+echo $MAJOR.$(($MINOR + 1)).0


### PR DESCRIPTION
Here we use seconds (/60) instead of seconds total. This should keep us under [`MAX_SAFE_INTEGER`](https://github.com/npm/node-semver/blob/bce42589d33e1a99454530a8fd52c7178e2b11c1/internal/constants.js) as defined by npm.