### PR TITLE
Update workflows for GoReleaser 2.0

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -19,5 +19,5 @@ jobs:
     uses: ./.github/workflows/stage-publish.yml
     secrets: inherit
     with:
-      goreleaser-args: -p 10 -f .goreleaser.yml --rm-dist --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
       vsce-full-release: true

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -21,4 +21,4 @@ jobs:
     uses: ./.github/workflows/stage-publish.yml
     secrets: inherit
     with:
-      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md
+      goreleaser-args: -p 10 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s --release-notes=CHANGELOG_PENDING.md

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,7 +1,6 @@
 dist: goreleaser
 project_name: pulumi-lsp
-changelog:
-  skip: true
+version: 2
 release:
   disable: true
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 dist: goreleaser
 project_name: pulumi-lsp
+version: 2
 snapshot:
   name_template: "{{ .Version }}-SNAPSHOT"
 checksum:


### PR DESCRIPTION
Similar to what we did in https://github.com/pulumi/pulumi-converter-terraform/pull/157:

> Goreleaser 2.0 gets installed automatically by the action. Rather than rolling back, fix it forward. In particular this skip-validate flag was replaced by skip=validate, and the config files need to be version 2.

Fixes #97