### PR TITLE
Explicitly disable CGO in .goreleaser.yml

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -15,6 +15,8 @@ archives:
 builds:
   - id: pulumi-lsp
     binary: pulumi-lsp
+    env:
+      - CGO_ENABLED=0
     goarch:
       - amd64
       - arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,8 @@ archives:
 builds:
   - id: pulumi-lsp
     binary: pulumi-lsp
+    env:
+      - CGO_ENABLED=0
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
In other repos, we've run into problems when the runner used to publish builds switched from macOS to Ubuntu because CGO is disabled by default on macOS but enabled on Ubuntu, and when CGO is enabled, by default the built binary will be dynamically linked. We want statically linked files on Linux so the binary works across different OSes.

This commit preemptively explicitly disables CGO in `.goreleaser.yml` and `.goreleaser.prerelease.yml` to ensure the binaries remain statically linked if/when the GHA runner is changed to Ubuntu.

Reference: https://github.com/pulumi/pulumi-yaml/pull/657

Fixes #112
