### PR TITLE
Attempt to fix publishing steps

### DIFF
--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -50,25 +50,25 @@ jobs:
             file: windows_amd64_v1
           - platform: win32
             arch: arm64
-            file: windows_arm64
+            file: windows_arm64_v8.0
           - platform: linux
             arch: x64
             file: linux_amd64_v1
           - platform: linux
             arch: arm64
-            file: linux_arm64
+            file: linux_arm64_v8.0
           - platform: linux
             arch: armhf
-            file: linux_arm64
+            file: linux_arm64_v8.0
           - platform: alpine
             arch: x64
-            file: linux_arm64
+            file: linux_amd64_v1
           - platform: darwin
             arch: x64
             file: darwin_amd64_v1
           - platform: darwin
             arch: arm64
-            file: darwin_arm64
+            file: darwin_arm64_v8.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The publishing steps in this repository have been broken for a while now, due to a mismatch when extracted artifacts produced by GoReleaser. Specifically, ARM64 artifacts now end up with an appended MIPS version, which for us appears to always be 8.0. It's not clear to me when this mismatch was first introduced, though I suspect it was triggered by some new GoReleaser version being pulled by the action (since we don't pin a version) and has been broken ever since. In this change I've modified the expected filenames (I believe), which I think will fix things, though someone reviewing this may have a better idea/a real solution if this is just symptom curing.

> [!NOTE]
> It appears that the `alpine` entry has been using ARM64 binaries,
> despite being listed as an `x64` architecture, so I've changed this.
> Is this correct?